### PR TITLE
Don't evaluate any chunks

### DIFF
--- a/abstract.Rmd
+++ b/abstract.Rmd
@@ -15,7 +15,7 @@ output:
 ---
 
 ```{r, echo = FALSE, warning = FALSE, message = FALSE}
-knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
+knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE, eval = FALSE)
 ```
 \begin{abstract}
 Hopefully this will help formate the entire paper according the arxiv latex template. I imagine there will be plenty of kinks in the road yet!


### PR DESCRIPTION
In order to compile the document without running any of the analyses, added `eval = FALSE` to `knitr::opts_chunk$set` in initial call from `abstract.Rmd`.