### PR TITLE
Pro ter Fluorescence plots

### DIFF
--- a/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mCh-ter_swaps_analysis.Rmd
+++ b/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mCh-ter_swaps_analysis.Rmd
@@ -6,7 +6,7 @@ output: html_document
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
+knitr::opts_chunk$set(echo = TRUE, fig.path = "figure/pro-mCh-ter-swaps-")
 
 library(ggplot2)
 library(tidyverse)
@@ -18,6 +18,15 @@ library(dplyr)
 
 
 source(here("raw_data_analysis/code/shared_figure_formatting.R"))
+```
+
+```{r labels_pro_ter}
+# define promoter and terminator levels in desired order
+pro6  <- c("pPGK1", "pHSP26", "pRPS3", "pRPS13", "pSRO9", "pCLN2")
+pro4  <- c("pPGK1", "pHSP26", "pRPS3", "pRPS13")
+ter10 <- c("tPGK1", "tHSP26", "tRPS3", "tRPS13",
+           "tSRO9", "tCLN2", "tPAB1", 
+           "tSUN4", "tTOS6", "tPMA1")
 ```
 
 
@@ -49,13 +58,15 @@ names(pro_mCh_ter_n6)[3] <- "mCh_per_OD_at_max_gr"
 
 pro_mCh_ter <-  bind_rows(pro_mCh_ter_n1, pro_mCh_ter_n2, pro_mCh_ter_n3, pro_mCh_ter_n4, pro_mCh_ter_n5, pro_mCh_ter_n6) %>%
         separate(sample_id, remove = FALSE,sep="_",into=c("Strain","BioRep")) %>%
-        filter(!Strain %in% c('Null', 'POT1-ccdB')) %>%
-        separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mCherry","Terminator"))
+  filter(!Strain %in% c('null', 'Null', 'POT1-ccdB')) %>%
+  separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mCherry","Terminator")) %>%
+  mutate(Promoter = factor(Promoter, levels = pro6),
+         Terminator = factor(Terminator, levels = ter10))
 ```
 
-```{r plot_norm, fig.width=8, fig.height=2}
+```{r plot_norm, fig.width=9, fig.height=5}
 plot_norm <- ggplot(data=pro_mCh_ter, aes(x=Terminator,y=mCh_per_OD_at_max_gr)) +
-  geom_point(aes(color=Terminator, shape=BioRep),
+  geom_point(aes(color=Terminator),
                position=position_dodge(width = 0.5),size=1.8, alpha=1) +
   labs(y="mCh fluorescence at maximum growth rate \n (normalised to OD)",x="Terminator") +
   facet_grid(~Promoter)+
@@ -71,15 +82,14 @@ plot_norm + stat_summary(aes(Terminator,mCh_per_OD_at_max_gr),
 
 ```{r plot_se, fig.width=8, fig.height=2}
 pro_mCh_ter_se <- pro_mCh_ter %>% 
-  group_by(Strain) %>% 
+  group_by(Strain,Promoter,Terminator) %>% 
   summarize(strain_mean = mean(mCh_per_OD_at_max_gr), # mean mCh fluorescence per strain
             strain_sd = sd(mCh_per_OD_at_max_gr), # mCh fluorescence sd per strain
             strain_n = n(),
             se = strain_sd/sqrt(strain_n), # mCh fluorescence se
             upper_limit = strain_mean+se, # Upper limit
             lower_limit = strain_mean-se # Lower limit
-            ) %>%
-        separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mCherry","Terminator"))
+            )
 pro_mCh_ter_se
 
 
@@ -297,16 +307,14 @@ norm_allplot_low_with_mean <- norm_allplot_low + stat_summary(aes(Terminator,nor
 
 ```{r plot_norm_se_1, fig.height=3, fig.width=6}
 norm_pro_mCh_ter_se <- norm_pro_mCh_ter_all %>% 
-  group_by(Strain) %>%
+  group_by(Strain,Promoter,Terminator) %>%
   summarize(strain_mean=mean(norm_mCh_per_OD_at_max_gr), 
             strain_sd=sd(norm_mCh_per_OD_at_max_gr), 
             strain_n=n(),
             se=strain_sd/sqrt(strain_n),
             upper_limit=strain_mean+se,
             lower_limit=strain_mean-se)  %>% 
-  ungroup()%>%
-  separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mCh","Terminator")) %>%
-  mutate(Terminator=factor(Terminator, levels=c("tPGK1", "tCLN2", "tHSP26", "tPAB1", "tPMA1", "tRPS3", "tRPS13", "tSRO9", "tSUN4", "tTOS6")))
+  ungroup()
 norm_pro_mCh_ter_se
 
 plot_norm_se <- ggplot(data=norm_pro_mCh_ter_se, aes(x=Promoter,y=strain_mean)) +

--- a/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mCh-ter_swaps_analysis.Rmd
+++ b/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mCh-ter_swaps_analysis.Rmd
@@ -68,7 +68,7 @@ pro_mCh_ter <-  bind_rows(pro_mCh_ter_n1, pro_mCh_ter_n2, pro_mCh_ter_n3, pro_mC
 plot_norm <- ggplot(data=pro_mCh_ter, aes(x=Terminator,y=mCh_per_OD_at_max_gr)) +
   geom_point(aes(color=Terminator),
                position=position_dodge(width = 0.5),size=1.8, alpha=1) +
-  labs(y="mCh fluorescence at maximum growth rate \n (normalised to OD)",x="Terminator") +
+  labs(y="mCh fluorescence/OD (AU)",x="Terminator") +
   facet_grid(~Promoter)+
   theme(axis.text.x=element_text(angle=90,vjust=0.5),
           axis.title.x=element_text(vjust=-2),
@@ -105,7 +105,9 @@ plot_se <- ggplot(data=pro_mCh_ter_se,
 plot_se
 ```
 
+## Normalize relative to tPGK1
 
+These next code chunks, until `tPGK1norm_combined`, can be combined into one using `group_by` - perhaps using `tidyqpcr::calculate_normvalue` on the way.
 
 ```{r pPGK1_tPGK1_norm, fig.width=3, fig.height=2}
 pro_mCh_ter_pPGK1 <- pro_mCh_ter %>%
@@ -320,7 +322,7 @@ norm_pro_mCh_ter_se
 plot_norm_se <- ggplot(data=norm_pro_mCh_ter_se, aes(x=Promoter,y=strain_mean)) +
   geom_point(aes(color=Promoter), size=2) +
   scale_colour_hue(h = c(0, 360)+20,l=60,c=60)+
-  labs(y="Relative mCh fluorescence per OD \n relative to tPGK1",x="Promoter") +
+  labs(y="mCh fluorescence/OD \n relative to tPGK1",x="Promoter") +
   facet_wrap(~Terminator, nrow=2)+
   theme(axis.text.x=element_text(angle=90,vjust=0.5),
           axis.title.x=element_text(vjust=-2),
@@ -333,7 +335,7 @@ plot_norm_se
 ```{r plot_norm_se_2, fig.height=3, fig.width=6}
 plot_norm_se_2 <- ggplot(data=norm_pro_mCh_ter_se, aes(x=Terminator,y=strain_mean)) +
   geom_point(aes(color=Terminator), size=2) +
-  labs(y="Relative mCh fluorescence per OD \n relative to tPGK1",x="Terminator") +
+  labs(y="mCh fluorescence/OD \n relative to tPGK1",x="Terminator") +
   facet_wrap(~Promoter, nrow=2)+
   scale_colour_hue(h = c(0, 360)+20,l=60,c=60)+
   theme(axis.text.x=element_text(angle=90,vjust=0.5),
@@ -342,6 +344,21 @@ plot_norm_se_2 <- ggplot(data=norm_pro_mCh_ter_se, aes(x=Terminator,y=strain_mea
   geom_errorbar(aes(ymax = strain_mean+se, ymin = strain_mean-se, color=Terminator,  width=0.4))+
   geom_hline(yintercept=1, linetype="dotted", color = "grey50")
 plot_norm_se_2
+```
+
+```{r plot_norm_se_pro4, fig.height=3, fig.width=7}
+plot_norm_se_pro4 <- ggplot(data=filter(norm_pro_mCh_ter_se, Promoter %in% pro4),
+                            aes(x=Terminator,y=strain_mean)) +
+  geom_point(aes(color=Terminator), size=2) +
+  labs(y="mCh fluorescence/OD \n relative to tPGK1",x="Terminator") +
+  facet_wrap(~Promoter, nrow=1)+
+  scale_colour_hue(h = c(0, 360)+20,l=60,c=60)+
+  theme(axis.text.x=element_text(angle=90,vjust=0.5),
+          axis.title.x=element_text(vjust=-2),
+          axis.title.y=element_text(vjust=3))+
+  geom_errorbar(aes(ymax = strain_mean+se, ymin = strain_mean-se, color=Terminator,  width=0.4))+
+  geom_hline(yintercept=1, linetype="dotted", color = "grey50")
+plot_norm_se_pro4
 ```
 
 ```{r plot_norm_all_points, fig.height=3, fig.width=6}

--- a/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mTurq-ter_swaps_analysis.Rmd
+++ b/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mTurq-ter_swaps_analysis.Rmd
@@ -1,22 +1,34 @@
 ---
-title: "Promoter-Terminator_fullplate_analysis"
+title: "Promoter-mTurquoise-Terminator_fullplate_analysis"
 author: "Jamie Auxillos"
 date: "25/12/2020"
 output: html_document
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
+knitr::opts_chunk$set(echo = TRUE, fig.path = "figure/pro-mTurq-ter-swaps-")
 
 library(ggplot2)
 library(tidyverse)
 library(cowplot)
 library(tidyqpcr)
-library(dplyr) 
+library(dplyr)
+library(here)
 
 
 source(here("raw_data_analysis/code/shared_figure_formatting.R"))
 ```
+
+
+```{r labels_pro_ter}
+# define promoter and terminator levels in desired order
+pro6  <- c("pPGK1", "pHSP26", "pRPS3", "pRPS13", "pSRO9", "pCLN2")
+pro4  <- c("pPGK1", "pHSP26", "pRPS3", "pRPS13")
+ter10 <- c("tPGK1", "tHSP26", "tRPS3", "tRPS13",
+           "tSRO9", "tCLN2", "tPAB1", 
+           "tSUN4", "tTOS6", "tPMA1")
+```
+
 
 
 ```{r}
@@ -46,15 +58,36 @@ names(pro_mTurq_ter_n6)[3] <- "mTurq_per_OD_at_max_gr"
 
 
 pro_mTurq_ter <-  bind_rows(pro_mTurq_ter_n1, pro_mTurq_ter_n2, pro_mTurq_ter_n3, pro_mTurq_ter_n4, pro_mTurq_ter_n5, pro_mTurq_ter_n6) %>%
-        filter(!Strain %in% c('Null', 'POT1-ccdB')) %>%
-        separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mTurq","Terminator"))
+  filter(!Strain %in% c('null', 'Null', 'POT1-ccdB')) %>%
+  separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mTurq","Terminator")) %>%
+  mutate(Promoter = factor(Promoter, levels = pro6),
+         Terminator = stringr::str_remove(Terminator, "_long") %>% 
+           factor(levels = ter10))
 ```
 
-```{r plot_norm, fig.width=8, fig.height=2}
-plot_norm <- ggplot(data=pro_mTurq_ter, aes(x=Terminator,y=mTurq_per_OD_at_max_gr)) +
+
+```{r plot_norm_tPGK1, fig.width=9, fig.height=5}
+plot_norm <- ggplot(data=filter(pro_mTurq_ter, Terminator == "tPGK1"), 
+                    aes(x=Terminator,y=mTurq_per_OD_at_max_gr)) +
   geom_point(aes(color=Terminator),
                position=position_dodge(width = 0.5),size=1.8, alpha=1) +
-  labs(y="mTurq fluorescence at maximum growth rate \n (normalised to OD)",x="Terminator") +
+  labs(y="mTu fluorescence/OD (AU)",x="Terminator") +
+  facet_grid(~Promoter) + 
+  theme(axis.text.x=element_text(angle=90,vjust=0.5),
+          axis.title.x=element_text(vjust=-2),
+          axis.title.y=element_text(vjust=3))
+
+plot_norm + stat_summary(aes(Terminator,mTurq_per_OD_at_max_gr),
+    fun="mean",colour="black",
+    geom="crossbar",size=0.2, width=0.5) 
+```
+
+```{r plot_norm, fig.width=9, fig.height=5}
+plot_norm <- ggplot(data=pro_mTurq_ter, 
+                    aes(x=Terminator,y=mTurq_per_OD_at_max_gr)) +
+  geom_point(aes(color=Terminator),
+               position=position_dodge(width = 0.5),size=1.8, alpha=1) +
+  labs(y="mTu fluorescence/OD (AU)",x="Terminator") +
   facet_grid(~Promoter)+
   theme(axis.text.x=element_text(angle=90,vjust=0.5),
           axis.title.x=element_text(vjust=-2),
@@ -68,15 +101,14 @@ plot_norm + stat_summary(aes(Terminator,mTurq_per_OD_at_max_gr),
 
 ```{r plot_se, fig.width=8, fig.height=2}
 pro_mTurq_ter_se <- pro_mTurq_ter %>% 
-  group_by(Strain) %>% 
+  group_by(Strain,Promoter,Terminator) %>% 
   summarize(strain_mean = mean(mTurq_per_OD_at_max_gr), # mean mTurq fluorescence per strain
             strain_sd = sd(mTurq_per_OD_at_max_gr), # mTurq fluorescence sd per strain
             strain_n = n(),
             se = strain_sd/sqrt(strain_n), # mTurq fluorescence se
             upper_limit = strain_mean+se, # Upper limit
             lower_limit = strain_mean-se # Lower limit
-            ) %>%
-        separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mTurq","Terminator"))
+            )
 pro_mTurq_ter_se
 
 
@@ -295,22 +327,20 @@ plot_grid(norm_allplot_high_with_mean,norm_allplot_low_with_mean,ncol = 1)
 
 ```{r plot_norm_se_1, fig.height=3, fig.width=6}
 norm_pro_mTurq_ter_se <- norm_pro_mTurq_ter_all %>% 
-  group_by(Strain) %>%
+  group_by(Strain,Promoter,Terminator) %>% 
   summarize(strain_mean=mean(norm_mTurq_per_OD_at_max_gr), 
             strain_sd=sd(norm_mTurq_per_OD_at_max_gr), 
             strain_n=n(),
             se=strain_sd/sqrt(strain_n),
             upper_limit=strain_mean+se,
             lower_limit=strain_mean-se)  %>% 
-  ungroup()%>%
-  separate(Strain, remove = FALSE,sep="-",into=c("Promoter","mTurq","Terminator")) %>%
-  mutate(Terminator=factor(Terminator, levels=c("tPGK1", "tCLN2", "tHSP26", "tPAB1", "tPMA1_long", "tRPS3", "tRPS13", "tSRO9_long", "tSUN4", "tTOS6")))
+  ungroup()
 norm_pro_mTurq_ter_se
 
 plot_norm_se <- ggplot(data=norm_pro_mTurq_ter_se, aes(x=Promoter,y=strain_mean)) +
   geom_point(aes(color=Promoter), size=2) +
   scale_colour_hue(h = c(0, 360)+20,l=60,c=60)+
-  labs(y="Relative mTurq fluorescence per OD \n relative to tPGK1",x="Promoter") +
+  labs(y="mTu fluorescence/OD \n relative to tPGK1",x="Promoter") +
   facet_wrap(~Terminator, nrow=2)+
   theme(axis.text.x=element_text(angle=90,vjust=0.5),
           axis.title.x=element_text(vjust=-2),
@@ -323,7 +353,7 @@ plot_norm_se
 ```{r plot_norm_se_2, fig.height=3, fig.width=6}
 plot_norm_se_2 <- ggplot(data=norm_pro_mTurq_ter_se, aes(x=Terminator,y=strain_mean)) +
   geom_point(aes(color=Terminator), size=2) +
-  labs(y="Relative mTurq fluorescence per OD \n relative to tPGK1",x="Terminator") +
+  labs(y="mTu fluorescence/OD \n relative to tPGK1",x="Terminator") +
   facet_wrap(~Promoter, nrow=2)+
   scale_colour_hue(h = c(0, 360)+20,l=60,c=60)+
   theme(axis.text.x=element_text(angle=90,vjust=0.5),
@@ -335,9 +365,11 @@ plot_norm_se_2
 ```
 ```{r plot_norm_all_points, fig.height=3, fig.width=6}
 
-mTurq_platereader_figure <- ggplot(data=norm_pro_mTurq_ter_all %>% mutate(Terminator = str_remove(Terminator, "_long")), aes(x=Terminator,y=norm_mTurq_per_OD_at_max_gr, colour = Terminator)) +
+mTurq_platereader_figure <- 
+  ggplot(data=norm_pro_mTurq_ter_all,
+         aes(x=Terminator,y=norm_mTurq_per_OD_at_max_gr, colour = Terminator)) +
   geom_point() +
-  labs(y="Relative mTurq fluorescence per OD \n relative to tPGK1",x="Terminator") +
+  labs(y="mTu fluorescence/OD \n relative to tPGK1",x="Terminator") +
   facet_wrap(~Promoter, nrow=2)+
   scale_colour_hue(h = c(0, 360)+20,l=60,c=60)+
   theme(axis.text.x=element_text(angle=90,vjust=0.5),
@@ -353,7 +385,6 @@ ggsave(here("./results_chapter/figures/pro_ter_platereader_mTurq.png"),mTurq_pla
 
 ```{r radarGraphDraft}
 norm_pro_mTurq_ter_se %>%
-  mutate(Terminator = str_remove(Terminator, "_long")) %>%
   select(Promoter,Terminator, strain_mean) %>%
   filter(Terminator %in% c("tPGK1", "tSUN4", "tTOS6", "tSRO9", "tPMA1")) %>%
   transmute(group=factor(Terminator, levels = c("tSUN4", "tTOS6", "tSRO9", "tPMA1", "tPGK1")), Promoter, strain_mean) %>%
@@ -363,7 +394,6 @@ norm_pro_mTurq_ter_se %>%
 
 
 norm_pro_mTurq_ter_se %>%
-  mutate(Terminator = str_remove(Terminator, "_long")) %>%
   select(Promoter,Terminator, strain_mean) %>%
   filter(Terminator %in% c("tPGK1", "tRPS3", "tPAB1", "tHSP26", "tRPS13", "tCLN2")) %>%
   transmute(group=factor(Terminator, levels = c("tPAB1", "tPGK1", "tCLN2", "tRPS13", "tRPS3", "tHSP26")), Promoter, strain_mean) %>%

--- a/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mTurq-ter_swaps_analysis.Rmd
+++ b/raw_data_analysis/code/platereader/promoter_terminator_swaps/pro-mTurq-ter_swaps_analysis.Rmd
@@ -124,7 +124,9 @@ plot_se <- ggplot(data=pro_mTurq_ter_se,
 plot_se
 ```
 
+## Normalize relative to tPGK1
 
+These next code chunks, until `tPGK1norm_combined`, can be combined into one using `group_by` - perhaps using `tidyqpcr::calculate_normvalue` on the way.
 
 ```{r pPGK1_tPGK1_norm, fig.width=3, fig.height=2}
 pro_mTurq_ter_pPGK1 <- pro_mTurq_ter %>%
@@ -201,6 +203,7 @@ normRPS13plot + stat_summary(aes(Terminator,norm_mTurq_per_OD_at_max_gr),
     fun="mean",colour="black",
     geom="crossbar",size=0.2, width=0.5) 
 ```
+
 ```{r pHSP26_tPGK1_norm, fig.width=3, fig.height=2}
 pro_mTurq_ter_pHSP26 <- pro_mTurq_ter %>%
                   filter(Promoter %in% c('pHSP26'))
@@ -363,6 +366,22 @@ plot_norm_se_2 <- ggplot(data=norm_pro_mTurq_ter_se, aes(x=Terminator,y=strain_m
   geom_hline(yintercept=1, linetype="dotted", color = "grey50")
 plot_norm_se_2
 ```
+
+```{r plot_norm_se_pro4, fig.height=3, fig.width=7}
+plot_norm_se_pro4 <- ggplot(data=filter(norm_pro_mTurq_ter_se, Promoter %in% pro4),
+                            aes(x=Terminator,y=strain_mean)) +
+  geom_point(aes(color=Terminator), size=2) +
+  labs(y="mTu fluorescence/OD \n relative to tPGK1",x="Terminator") +
+  facet_wrap(~Promoter, nrow=1)+
+  scale_colour_hue(h = c(0, 360)+20,l=60,c=60)+
+  theme(axis.text.x=element_text(angle=90,vjust=0.5),
+          axis.title.x=element_text(vjust=-2),
+          axis.title.y=element_text(vjust=3))+
+  geom_errorbar(aes(ymax = strain_mean+se, ymin = strain_mean-se, color=Terminator,  width=0.4))+
+  geom_hline(yintercept=1, linetype="dotted", color = "grey50")
+plot_norm_se_pro4
+```
+
 ```{r plot_norm_all_points, fig.height=3, fig.width=6}
 
 mTurq_platereader_figure <- 


### PR DESCRIPTION
Extensive, although incomplete, edits to `pro-mCh-ter_swaps_analysis.Rmd` and
`pro-mTurq-ter_swaps_analysis.Rmd`.

* made promoter and terminators factors with levels set at beginning
* removed 'null' as well as 'Null' values
* group_by(Strain,Terminator,Promoter) keeps factor levels
* extra tPGK1-only plot in mTurq
* some code tidying
*  new pro-ter swaps figure normalized to tPGK1 with only 4 promoters
* added notes about normalization
* changed some plot labels and axis labels.

Still to do: in section **Normalize relative to tPGK1**, These next code chunks, until `tPGK1norm_combined`, can be combined into one using `group_by` - perhaps using `tidyqpcr::calculate_normvalue` on the way.

