### PR TITLE
Sam abstract intro

### DIFF
--- a/abstract.Rmd
+++ b/abstract.Rmd
@@ -18,12 +18,12 @@ knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
 library(bookdown)
 ```
 \begin{abstract}
-Cis-regulatory elements (CREs) determining gene expression are abstracted into discrete modules, such as promoter, coding sequence, and terminator, and short sequence motifs within those.
-Current cloning techniques mean that CREs are easy to construct and combine, i.e. they are practically modular.
-However, it is unclear how much the effect of CREs on gene expression outcomes depends on other elements present in the same gene: are they functionally modular?
-We probe the limitations of assuming independent effects in budding yeast, by confirming that the quantitative effect of a terminator depends on both promoter and coding sequence.
+In order to understand gene expression, genes are commonly abstracted into cis-regulatory elements (CREs), such as promoter, coding sequence, and terminator, and short sequence motifs within those.
+Current cloning techniques assume CREs are discrete modules and, therefore, that they are easy to construct and combine.
+However, it is unclear how dependent the contributions of CREs to gene expression are on the context of its host gene.
+Using the model organism S.cer, we probe the limitations of assuming independent effects and confirm that the quantitative effect of a terminator depends on both promoter and coding sequence.
 Next, we explore whether individual cis-regulatory motifs within terminator regions display similar context dependence.
-We focus on suspected protein binding motifs in mRNA transcript 3'UTRs, inferred from transcriptome-wide datasets of mRNA decay.
+We focus on suspected protein binding motifs in mRNA transcript 3’UTRs, inferred from transcriptome-wide datasets of mRNA decay.
 Then we construct reporter genes with different combinations of inserted or removed motifs in 3 different terminator contexts, each expressed from 3 different promoters.
 Our results show that the effects of individual CREs depend both on their host terminator, and also on the paired promoter at the opposite end of the coding sequence.
 Observations that the same CRE can regulate gene expression differently in different host genes suggests that complex regulatory patterns are ubiquitous and need to be accounted for in designing synthetic genes.

--- a/discussion_chapter/discussion.Rmd
+++ b/discussion_chapter/discussion.Rmd
@@ -39,31 +39,25 @@ It encodes a small RNA transcript that binds to a repeated 3'UTR motif and inhib
 Lin-14 is required for the first stage of larval development but it inhibits the progression to the second stage.
 Therefore, since lin-4 is only expressed at the end of the first development stage, the 3'UTR motifs in lin-14 only begin to inhibit its translation late into stage 1, initiating the start of stage 2. [@Olsen1999]
 
-The internal context of a motif can be critical in enabling regulation.
-Motifs will are dependent on the secondary structure and presence (or absence) of other regulatory elements within the host transcript.
+Motif behaviour can also be affected by the internal context of the entire host transcript.
 Secondary structures can be integral to a motifs function, such as the SHE2 binding motif spread across stem loops within ASH1 transcripts or the Smg recognition elements found in transcript targets of Vts1p [@Olivier2005; @Aviv2006]. 
 In other cases, secondary structures can have an overall inhibitory effect on binding, with the presence of stable stem loops within the 3’UTR reducing the binding of known destabilising RBPs [@Geisberg2020].
-Alternatively, motifs often need to be repeated in the same transcript or appear alongside other motifs.
-For efficient binding as some effector proteins bind indirectly through multiple recruiter proteins, for example Ski2 or Mtr4 recruitment of the exosome for 5'-3' mRNA decay in the cytoplasm or nucleus respectively (Thom et al., 2015; Weick and Lima, 2021), or bind directly with multi-partite motifs separated by unconserved gaps of varying length, such as SSD1's general binding motif CNYUCNYU and upstream CCAACU supplementary motif (Bayne et al., 2020) or PUF3's two bipartite motifs (Jackson et al., 2004). 
+For others still, multiple motifs, or multiple copies of the same motif, must occur together to enable recruitment of the effector protein.  
+Recruitment of the Puf3, for example, in the signaling of mRNA transcript decay requires two motifs to be appear in the 3'UTR [@Jackson2004].
 
 
 ## Implications for novel cis-regulatory element searches
 
-Future motif detecting algorithms need to incorporate transcript context: secondary structure, localisation and cell cycle expression, for more accurate and comprehensive search results.
-Secondary structure features can be included in motif searches a priori by setting nucleotides within single stranded regions to be more likely to be part of motifs, by incorporating predicted binding energy.
-Non-linear relationships between intrinsic and extrinsic transcript characteristics can be modeled by partition regression techniques, such as random forests.
-Linear regression algorithms assume increased motif occurrence must increase protein binding, which causes a subsequent increase in the protein's functional effect.
-However, some motifs may need to be present above a threshold before sufficiently affecting binding or can behave differently in the presence of other co-regulatory motifs.
-In addition, linear models will also struggle with the behavior of some extrinsic effects, such as the availability of a binding protein in a particular organelle or at a cell cycle stage.
-These are either dominant predictors of motif efficacy or entirely irrelevant with such extreme behavior being poorly modeled by linear regression. 
-Combining partitioning algorithms to separate transcripts with dichotomised features followed by training linear regression models on the separate pool could best predict functional data sets, although overfitting will be serious concern. 
+Motif detection algorithms need to remove the assumption that the presence of a motif alone ensures its functional effect.
+The effect of a motif is not only dependent on its external and internal context, but also on experimental factors, such as; growth conditions and time of measurement.
+Uncertainty around the active state of a motif could be introduced using latent variables, as used in transcription factor (TF) binding site prediction algorithms to represent the proportion of active TF sites [@Dai2017; @Sanguinetti2006].
+Alternatively, non-linear relationships between factors affecting motif activity can be modeled by partition regression techniques, such as random forests.
+Again looking at TF algorithms, partitioning algorithms could be used to predict functional data sets using short sub-sequences of transcripts [@BehjatiArdakani2019]. 
 
-
-
-The growing catalogue of RBPs with multiple binding motifs has lead to a demand for methods that discover multi-partite motifs, which may be separated in a transcript's linear sequence but adjacent in the final 3D structure.
-Algorithms that determine position weight matrices for a linear segment of fixed length are unreliable when searching for motifs of variable widths and struggle with multi-partate motifs unless parts are directly adjacent in the linear sequence.
-k-mer based searches ignore motif position, enabling for the detection of separated, multi-partate motifs, but can only detect exact matches, therefore motifs with highly redundant nucleotides are missed.
-Deep learning algorithms can accurately model complex motif interactions, but interpreting the model features into biologically relevant motifs remains a serious constraint.
+Reductionist search algorithms that attempt to discover the shortest possible sequence contributing to expression are limiting the discovery of novel CREs. 
+High resolution maps of protein-RNA interactions are revealing RBPs with gapped, multi-partite motifs [@Bayne2020] or motifs that must be repeated in the same transcript to be effective (???????).
+Common motif searching algorithms, such as MEME Suite [@Bailey2015], have extended beyond fixed length, gapless motifs but still assume motifs occur independently and only once per transcript [@Frith2008].
+Although reducing the search constraints to allow longer, gaped motifs does increase the false discovery rate, the availability of precise interactome data sets shifts the priority towards more flexible search algorithms.
 
 ## Implications for experimental biology
 

--- a/references/chimeraProject.bib
+++ b/references/chimeraProject.bib
@@ -386,6 +386,95 @@ keywords = {Metabolic engineering, Terminator region, 3′-UTR activity, Fluores
 abstract = {Strong terminator regions could be used to improve metabolically engineered yeasts by increasing the target enzyme protein yields above those achieved with traditional terminator regions. We recently identified five strong terminator regions (RPL41Bt, RPL15At, DIT1t, RPL3t, and IDP1t) in a comprehensive analysis of Saccharomyces cerevisiae. The effect of the terminator regions was analyzed by measuring the protein production of a linked transgene, and was shown to be twice that of a traditional terminator region (PGK1t). Here, we investigated whether the activity of the terminator regions is affected by exchange of a strong promoter or reporter in the linked transgene, carbon source for cell growth, stress factors, host yeast strain, or stage of the growth phase. Our results indicate that the activities of all five terminator regions were twice that of PGK1t in all conditions tested. In addition, we demonstrated that the strong activity of these terminator regions could be used to improve secretory production of endoglucanase II derived from Tricoderma ressei, and that the DIT1t strain was the best of the five strains for this purpose. We therefore propose that DIT1t, and the four other terminator regions, could be applied to the development of improved metabolically engineered yeasts.}
 }
 
+@article{Frith2008,
+   abstract = {Biology is encoded in molecular sequences: deciphering this encoding remains a grand scientific challenge. Functional regions of DNA, RNA, and protein sequences often exhibit characteristic but subtle motifs; thus, computational discovery of motifs in sequences is a fundamental and much-studied problem. However, most current algorithms do not allow for insertions or deletions (indels) within motifs, and the few that do have other limitations. We present a method, GLAM2 (Gapped Local Alignment of Motifs), for discovering motifs allowing indels in a fully general manner, and a companion method GLAM2SCAN for searching sequence databases using such motifs. GLAM2 is a generalization of the gapless Gibbs sampling algorithm. It re-discovers variable-width protein motifs from the PROSITE database significantly more accurately than the alternative methods PRATT and SAM-T2K. Furthermore, it usefully refines protein motifs from the ELM database: in some cases, the refined motifs make orders of magnitude fewer overpredictions than the original ELM regular expressions. GLAM2 performs respectably on the BAliBASE multiple alignment benchmark, and may be superior to leading multiple alignment methods for "motif-like" alignments with N- and C-terminal extensions. Finally, we demonstrate the use of GLAM2 to discover protein kinase substrate motifs and a gapped DNA motif for the LIM-only transcriptional regulatory complex: using GLAM2SCAN, we identify promising targets for the latter. GLAM2 is especially promising for short protein motifs, and it should improve our ability to identify the protein cleavage sites, interaction sites, post-translational modification attachment sites, etc., that underlie much of biology. It may be equally useful for arbitrarily gapped motifs in DNA and RNA, although fewer examples of such motifs are known at present. GLAM2 is public domain software, available for download at http://bioinformatics.org.au/glam2. © 2008 Frith et al.},
+   author = {Martin C. Frith and Neil F. W. Saunders and Bostjan Kobe and Timothy L. Bailey},
+   doi = {10.1371/journal.pcbi.1000071},
+   editor = {Gary Stormo},
+   issn = {1553-7358},
+   issue = {5},
+   journal = {PLoS Computational Biology},
+   month = {5},
+   pages = {e1000071},
+   publisher = {Public Library of Science},
+   title = {Discovering Sequence Motifs with Arbitrary Insertions and Deletions},
+   volume = {4},
+   url = {https://dx.plos.org/10.1371/journal.pcbi.1000071},
+   year = {2008},
+}
+
+@article{Jackson2004,
+   abstract = {The Puf family of RNA-binding proteins regulates mRNA translation and decay via interactions with 3′ untranslated regions (3′ UTRs) of target mRNAs. In yeast, Puf3p binds the 3′ UTR of COX17 mRNA and promotes rapid deadenylation and decay. We have investigated the sequences required for Puf3p recruitment to this 3′ UTR and have identified two separate binding sites. These sites are specific for Puf3p, as they cannot bind another Puf protein, Puf5p. Both sites use a conserved UGUANAUA sequence, whereas one site contains additional sequences that enhance binding affinity. In vivo, presence of either site partially stimulates COX17 mRNA decay, but full decay regulation requires the presence of both sites. No other sequences outside the 3′ UTR are required to mediate this decay regulation. The Puf repeat domain of Puf3p is sufficient not only for in vitro binding to the 3′ UTR, but also in vivo stimulation of COX17 mRNA decay. These experiments indicate that the essential residues involved in mRNA decay regulation are wholly contained within this RNA-binding domain.},
+   author = {John S. Jackson and S. Sean Houshmandi and Florencia Lopez Leban and Wendy M. Olivas},
+   doi = {10.1261/rna.7270204},
+   issn = {13558382},
+   issue = {10},
+   journal = {RNA},
+   keywords = {3′ UTR,Decay,Puf,Turnover,Yeast,mRNA},
+   month = {10},
+   pages = {1625-1636},
+   pmid = {15337848},
+   publisher = {Cold Spring Harbor Laboratory Press},
+   title = {Recruitment of the Puf3 protein to its mRNA target for regulation of mRNA decay in yeast},
+   volume = {10},
+   year = {2004},
+}
+
+@article {Bayne2020,
+	author = {Bayne, Rosemary A. and Jayachandran, Uma and Kasprowicz, Aleksandra and Bresson, Stefan and Tollervey, David and Wallace, Edward W. J. and Cook, Atlanta G.},
+	title = {Yeast Ssd1 is a non-enzymatic member of the RNase II family with an alternative RNA recognition interface},
+	elocation-id = {2020.10.22.350314},
+	year = {2020},
+	doi = {10.1101/2020.10.22.350314},
+	publisher = {Cold Spring Harbor Laboratory},
+	abstract = {The conserved fungal RNA binding protein Ssd1, is important in stress responses, cell division and virulence. Ssd1 is closely related to Dis3L2 of the RNase II family of nucleases, but lacks catalytic activity and may act by suppressing translation of associated mRNAs. Previous studies identified motifs that are enriched in Ssd1-associated transcripts, yet the sequence requirements for Ssd1 binding are not well understood. Here we present the crystal structure of Ssd1 at 1.9 {\r A} resolution. Active RNase II enzymes have a characteristic, internal RNA binding path, but in Ssd1 this is blocked by remnants of regulatory sequences. Instead, RNA binding activity has likely been relocated to the outer surface of the protein. Using in vivo crosslinking and cDNA analysis (CRAC), we identify Ssd1-RNA binding sites. These are strongly enriched in 5{\textquoteright}UTRs of a subset of mRNAs encoding cell wall proteins. Based on these and previous analyses, we identified a conserved bipartite motif that binds Ssd1 with high affinity in vitro. These studies provide a new framework for understanding the function of a pleiotropic post-transcriptional regulator of gene expression and give insights into the evolution of regulatory elements in the RNase II family.Competing Interest StatementThe authors have declared no competing interest.},
+	URL = {https://www.biorxiv.org/content/early/2020/10/22/2020.10.22.350314},
+	eprint = {https://www.biorxiv.org/content/early/2020/10/22/2020.10.22.350314.full.pdf},
+	journal = {bioRxiv}
+}
+
+@Article{ BehjatiArdakani2019,
+AUTHOR = { Behjati Ardakani, F and Schmidt, F and Schulz, MH},
+TITLE = {Predicting transcription factor binding using ensemble random forest models [version 2; peer review: 2 approved]
+},
+JOURNAL = {F1000Research},
+VOLUME = {7},
+YEAR = {2019},
+NUMBER = {1603},
+DOI = {10.12688/f1000research.16200.2}
+}
+
+@article{Sanguinetti2006,
+    author = {Sanguinetti, Guido and Lawrence, Neil D. and Rattray, Magnus},
+    title = "{Probabilistic inference of transcription factor concentrations and gene-specific regulatory activities}",
+    journal = {Bioinformatics},
+    volume = {22},
+    number = {22},
+    pages = {2775-2781},
+    year = {2006},
+    month = {09},
+    abstract = "{Motivation: Quantitative estimation of the regulatory relationship between transcription factors and genes is a fundamental stepping stone when trying to develop models of cellular processes. Recent experimental high-throughput techniques, such as Chromatin Immunoprecipitation (ChIP) provide important information about the architecture of the regulatory networks in the cell. However, it is very difficult to measure the concentration levels of transcription factor proteins and determine their regulatory effect on gene transcription. It is therefore an important computational challenge to infer these quantities using gene expression data and network architecture data.Results: We develop a probabilistic state space model that allows genome-wide inference of both transcription factor protein concentrations and their effect on the transcription rates of each target gene from microarray data. We use variational inference techniques to learn the model parameters and perform posterior inference of protein concentrations and regulatory strengths. The probabilistic nature of the model also means that we can associate credibility intervals to our estimates, as well as providing a tool to detect which binding events lead to significant regulation. We demonstrate our model on artificial data and on two yeast datasets in which the network structure has previously been obtained using ChIP data. Predictions from our model are consistent with the underlying biology and offer novel quantitative insights into the regulatory structure of the yeast cell.Availability: MATLAB code is available from Contact:guido@dcs.shef.ac.ukSupplementary information: Supplementary Data are available at Bioinformatics online}",
+    issn = {1367-4803},
+    doi = {10.1093/bioinformatics/btl473},
+    url = {https://doi.org/10.1093/bioinformatics/btl473},
+    eprint = {https://academic.oup.com/bioinformatics/article-pdf/22/22/2775/16851948/btl473.pdf},
+}
+
+@article{Dai2017,
+    author = {Dai, Zhenwen and Iqbal, Mudassar and Lawrence, Neil D and Rattray, Magnus},
+    title = "{Efficient inference for sparse latent variable models of transcriptional regulation}",
+    journal = {Bioinformatics},
+    volume = {33},
+    number = {23},
+    pages = {3776-3783},
+    year = {2017},
+    month = {08},
+    abstract = "{Regulation of gene expression in prokaryotes involves complex co-regulatory mechanisms involving large numbers of transcriptional regulatory proteins and their target genes. Uncovering these genome-scale interactions constitutes a major bottleneck in systems biology. Sparse latent factor models, assuming activity of transcription factors (TFs) as unobserved, provide a biologically interpretable modelling framework, integrating gene expression and genome-wide binding data, but at the same time pose a hard computational inference problem. Existing probabilistic inference methods for such models rely on subjective filtering and suffer from scalability issues, thus are not well-suited for realistic genome-scale applications.We present a fast Bayesian sparse factor model, which takes input gene expression and binding sites data, either from ChIP-seq experiments or motif predictions, and outputs active TF-gene links as well as latent TF activities. Our method employs an efficient variational Bayes scheme for model inference enabling its application to large datasets which was not feasible with existing MCMC-based inference methods for such models. We validate our method on synthetic data against a similar model in the literature, employing MCMC for inference, and obtain comparable results with a small fraction of the computational time. We also apply our method to large-scale data from Mycobacterium tuberculosis involving ChIP-seq data on 113 TFs and matched gene expression data for 3863 putative target genes. We evaluate our predictions using an independent transcriptomics experiment involving over-expression of TFs.An easy-to-use Jupyter notebook demo of our method with data is available at https://github.com/zhenwendai/SITAR.Supplementary data are available at Bioinformatics online.}",
+    issn = {1367-4803},
+    doi = {10.1093/bioinformatics/btx508},
+    url = {https://doi.org/10.1093/bioinformatics/btx508},
+    eprint = {https://academic.oup.com/bioinformatics/article-pdf/33/23/3776/25168082/btx508.pdf},
+}
 
 @article{Kretz2013,
    abstract = {Several of the thousands of human long non-coding RNAs (lncRNAs) have been functionally characterized; however, potential roles for lncRNAs in somatic tissue differentiation remain poorly understood. Here we show that a 3.7-kilobase lncRNA, terminal differentiation-induced ncRNA (TINCR), controls human epidermal differentiation by a post-transcriptional mechanism. TINCR is required for high messenger RNA abundance of key differentiation genes, many of which are mutated in human skin diseases, including FLG, LOR, ALOXE3, ALOX12B, ABCA12, CASP14 and ELOVL3. TINCR-deficient epidermis lacked terminal differentiation ultrastructure, including keratohyalin granules and intact lamellar bodies. Genome-scale RNA interactome analysis revealed that TINCR interacts with a range of differentiation mRNAs. TINCR-mRNA interaction occurs through a 25-nucleotide 'TINCR box' motif that is strongly enriched in interacting mRNAs and required for TINCR binding. A high-throughput screen to analyse TINCR binding capacity to approximately 9,400 human recombinant proteins revealed direct binding of TINCR RNA to the staufen1 (STAU1) protein. STAU1-deficient tissue recapitulated the impaired differentiation seen with TINCR depletion. Loss of UPF1 and UPF2, both of which are required for STAU1-mediated RNA decay, however, did not have differentiation effects. Instead, the TINCR-STAU1 complex seems to mediate stabilization of differentiation mRNAs, such as KRT80. These data identify TINCR as a key lncRNA required for somatic tissue differentiation, which occurs through lncRNA binding to differentiation mRNAs to ensure their expression. © 2013 Macmillan Publishers Limited. All rights reserved.},


### PR DESCRIPTION
My main change was to revert to saying genes are abstracted into CREs. I don't think it's correct to say CREs are abstracted into discrete modules. You can _assume_ CREs are discrete modules but I dont think that is an example of abstraction. The generalisation of genes as a combination of separate sequences with distinct functions is the abstraction.