### PR TITLE
Abstract edits

### DIFF
--- a/abstract.Rmd
+++ b/abstract.Rmd
@@ -18,15 +18,12 @@ knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
 library(bookdown)
 ```
 \begin{abstract}
-Genes are commonly abstracted into a coding sequence and cis-regulatory elements (CREs), such as promoter and terminator regions, and short sequence motifs within those.
-Modern cloning techniques allow easy assembly of synthetic genetic constructs using discrete cis-regulatory modules.
-However, it is unclear how much the contributions of CREs to gene expression depend on other CREs in the host gene.
-Using budding yeast, we probe the limitations of assuming composability, or independent effects, of distinct CREs.
-We confirm that the quantitative effect of a terminator on gene expression depends on both promoter and coding sequence.
-Next, we explore whether individual cis-regulatory motifs within terminator regions display similar context dependence.
-We focus on putative protein binding motifs in mRNA transcript 3’UTRs, inferred from transcriptome-wide datasets of mRNA decay.
-Then we construct reporter genes with different combinations of inserted or removed motifs in 3 different terminator contexts, each expressed from one of 3 different promoters.
-Our results show that the effects of short CREs depend both on their host terminator, and also on the associated promoter at the opposite end of the coding sequence.
-Observations that the regulation mediated by the same CRE can result in variable gene expression differently in different host genes suggests that complex regulatory patterns are ubiquitous and need to be accounted for in designing synthetic genetic constructs.
-Our results emphasise the need for improved CRE search algorithms that include both local and global context effects.
+Genes are commonly abstracted into a coding sequence and cis-regulatory elements (CREs), such as promoter and terminator regions, and short sequence motifs within these regions. 
+Modern cloning techniques allow easy assembly of synthetic genetic constructs from discrete cis-regulatory modules. 
+However, it is unclear how much the contributions of CREs to gene expression depend on other CREs in the host gene. Using budding yeast, we probe the limitations of assuming composability, or independent effects, of distinct CREs. 
+We confirm that the quantitative effect of a terminator on gene expression depends on both promoter and coding sequence. 
+We explore whether individual cis-regulatory motifs within terminator regions display similar context dependence, focussing on putative motifs predicted to be bound by RNA binding proteins, inferred using transcriptome-wide datasets of mRNA decay. 
+We then construct a library of diverse reporter genes, consisting of different combinations of motifs within various terminator contexts, paired with different promoters, to challenge the assumption of composability. 
+Our results show  that the impact of motifs depend both on their host terminator, and also on the associated promoter sequence. 
+Consequently, this emphasises the need for improved motif algorithms that include both local and global context effects, which in turn can aid researchers in more accurate predictions of gene expression activity when employing diverse CREs for the construction of synthetic genetic constructs. 
 \end{abstract}

--- a/abstract.Rmd
+++ b/abstract.Rmd
@@ -19,14 +19,14 @@ library(bookdown)
 ```
 \begin{abstract}
 Genes are commonly abstracted into a coding sequence and cis-regulatory elements (CREs), such as promoter and terminator regions, and short sequence motifs within those.
-Modern cloning techniques allow easy assembly of synthetic genes from discrete cis-regulatory modules.
+Modern cloning techniques allow easy assembly of synthetic genetic constructs using discrete cis-regulatory modules.
 However, it is unclear how much the contributions of CREs to gene expression depend on other CREs in the host gene.
 Using budding yeast, we probe the limitations of assuming composability, or independent effects, of distinct CREs.
 We confirm that the quantitative effect of a terminator on gene expression depends on both promoter and coding sequence.
 Next, we explore whether individual cis-regulatory motifs within terminator regions display similar context dependence.
-We focus on suspected protein binding motifs in mRNA transcript 3’UTRs, inferred from transcriptome-wide datasets of mRNA decay.
-Then we construct reporter genes with different combinations of inserted or removed motifs in 3 different terminator contexts, each expressed from 3 different promoters.
-Our results show that the effects of short CREs depend both on their host terminator, and also on the paired promoter at the opposite end of the coding sequence.
-Observations that the same CRE can regulate gene expression differently in different host genes suggests that complex regulatory patterns are ubiquitous and need to be accounted for in designing synthetic genes.
+We focus on putative protein binding motifs in mRNA transcript 3’UTRs, inferred from transcriptome-wide datasets of mRNA decay.
+Then we construct reporter genes with different combinations of inserted or removed motifs in 3 different terminator contexts, each expressed from one of 3 different promoters.
+Our results show that the effects of short CREs depend both on their host terminator, and also on the associated promoter at the opposite end of the coding sequence.
+Observations that the regulation mediated by the same CRE can result in variable gene expression differently in different host genes suggests that complex regulatory patterns are ubiquitous and need to be accounted for in designing synthetic genetic constructs.
 Our results emphasise the need for improved CRE search algorithms that include both local and global context effects.
 \end{abstract}


### PR DESCRIPTION
- latter half of the abstract was modified and truncated for clarity. 
- references to 'CRE motifs' and 'short CREs' were changed to 'motifs' for consistency across the abstract without defining that we refer to 'motifs' as 'short CREs' in this paper < this will be left till the introduction to define more extensively