### PR TITLE
Minor edits to results and discussion sections

### DIFF
--- a/discussion_chapter/discussion.Rmd
+++ b/discussion_chapter/discussion.Rmd
@@ -30,13 +30,13 @@ These disparities in predicted and experimentally verified regulatory behaviour 
 RNA-Seq results confirmed our conclusions on the effect of motif insertions on gene expression. 
 pRPS3-tRPS3 and pTSA1-tTSA1 constructs show similar relative abundances in the qPCR results as the RNA-Seq results. 
 However, pPGK1-tRPS3 results are skewed due to the unexpected low abundance of mod_NNN constructs in the RNA-Seq results, which all other constructs are normalised to.
-As the QuantSeq protocol we used for our RNA-Seq assay anchors reads to the poly(A) tail of transcripts we were able to determine the effect of inserting motifs on polyA site usage. 
+As the QuantSeq protocol we used for our RNA-Seq assay anchors reads to the poly(A) tail of transcripts we were able to determine the effect of inserting motifs on poly(A) site usage. 
 For tTSA1 constructs, inserting the motifs shifted the poly(A) sites 27 nucleotides downstream of their absolute positions in WT, or the exact size of the three insertion site combined.
 The sequences and relative usages of the poly(A) sites are not affected by inserting motifs.
 For tRPS3 constructs, poly(A) sites were again appropriately shifted downstream by the length of the insertions sites.
-However, a novel polyA site is introduced between the second and third motifs.
+However, a novel poly(A) site is introduced between the second and third motifs.
 It is known that efficiency elements in the terminators of yeast genes play an important role in efficient RNA transcription and that cleavage and polyadenylation sites occur a specific distance downstream of the efficiency elements [@Graber1999].
-Although efforts were made to avoid altering efficiency elements in native terminators, the creation of novel polyA site is likely due to the inserted motifs extending the distance between the efficiency elements and the native polyA sites. 
+Although efforts were made to avoid altering efficiency elements in native terminators, the creation of novel poly(A) site is likely due to the inserted motifs extending the distance between the efficiency elements and the native poly(A) sites. 
 Another possible explanation for the novel poly(A) site is that motifs 2 and 3 were inserted into a highly conserved region of Rps3 terminator [@Siepel2005].
 This might have disrupted an RBP target site or secondary structure in this region, leading to changes in polyadenylation site choice.
 Despite this the QuantSeq results do confirm that at least one copy of the motifs of interest are present in every major isoform for all constructs.

--- a/materials_and_methods_chapter/materials_and_methods.Rmd
+++ b/materials_and_methods_chapter/materials_and_methods.Rmd
@@ -66,27 +66,27 @@ We measured all +RT reactions in technical triplicate, and negative control -RT 
 We used the manufacturer's software to calculate quantification cycle (Cq) for each individual well using the fit points method, and exported both raw fluorescence and Cq data.
 All primer sets were thoroughly validated by serial dilution and by confirming amplicon size. Sequences are available in Supplementary Table \ref{tab:chimera-qpcr-primers-table}.
 
-RT-qPCR data was analysed using our tidyqpcr R package v2.1.0-beta (https://github.com/ewallace/tidyqpcr).
+RT-qPCR data was analysed using our tidyqpcr R package v0.3 (https://github.com/ewallace/tidyqpcr).
 For each biological replicate, $\Delta$Cq values were calculated by normalising the median mCherry Cq values by the median Cq values of the three reference genes (RPS3, PGK1 and URA3).
 For the constructs with motif insertions in terminators, $\Delta\Delta$Cq values were calculated by normalising mCherry $\Delta$Cq by that of control construct mod_NNN strains (with the corresponding promoter) for tRPS3 and tTSA1 consructs.
 For the constructs with motif deletions in terminators, $\Delta\Delta$Cq values were calculated by normalising mCherry $\Delta$Cq by that of the WT terminator (with the corresponding promoter) for tPIR1 constructs.
 Complete scripts for qPCR analysis, quality control, and figure generation are available online at https://github.com/DimmestP/chimera_project_manuscript/.
 
-RNA-seq library was prepared using QuantSeq 3' mRNA-Seq Library Prep Kit REV for Illumina (Lexogen).
+RNA-seq libraries were prepared using QuantSeq 3' mRNA-Seq Library Prep Kit REV for Illumina (Lexogen).
 500 ng of RNA (not treated with DNaseI) was used as input and manufacturer's protocol was followed without modifications.
 The number of amplification cycles was determined using PCR Add-on Kit for Illumina (Lexogen).
 The quality of the library was measured using Fragment Analyzer NGS Fragment Kit (1-6000bp) (Agilent).
 Pooled libraries were then sequenced using NextSeq 500/550 (Illumina) with paired-end reads using Custom Sequencing Primer to obtain 3'-end reads.
 
-5PSeq library was prepared as described in [@Zhang2021] with following modifications: anchored-oligodT was used instead of oligo-dT to allow for sequencing of 3'-ends; random primers were not used.
+5PSeq libraries were prepared as described in [@Zhang2021] with modifications to the reverse transcription step: anchored oligo(dT) was used instead of oligo(dT) to allow for sequencing of 3'-ends and random primers were not used.
 Library was sequenced using NextSeq system (Illumina) with paired-end reads.
 
-RNA-Seq alignment and quality control was conducted using a reproducible NextFlow pipeline available online at https://github.com/DimmestP/nextflow_paired_reads_pipeline. 
+RNA-Seq alignment and quality control was conducted using a pipeline available online at https://github.com/DimmestP/nextflow_paired_reads_pipeline, written in Nextflow [@DiTommaso2017]. 
 Quality control was conducted with FASTQC and MultiQC reports [@Ewels2016] and adapters were removed with Cutadapt [@Martin2011].
-Alignment was conducted with HISAT2 [@Kim2019], SAMtools [@Li2009] and BEDTools [@Quinlan2010].
-Only 5PSeq reads contain UMIs, which were used to deduplicate reads using UMI-tools [@Smith2017].
-Finally counts to genomic regions of interest were calculated using FeatureCounts [@Liao2014].
-5'P ends were analysed using fivepseq pipeline [@Nersisyan2020].
+Alignment was conducted with HISAT2 [@Kim2019], followed by processing with SAMtools [@Li2009] and BEDTools [@Quinlan2010].
+5PSeq reads contain UMIs, which were used to deduplicate reads using UMI-tools [@Smith2017]; QuantSeq reads do not.
+Counts to genomic regions of interest were calculated using FeatureCounts [@Liao2014].
+For 5PSeq data, 5'P ends were also analysed using fivepseq pipeline [@Nersisyan2020].
 
 
 ## Determining 3'UTR decay motifs

--- a/results_chapter/results.Rmd
+++ b/results_chapter/results.Rmd
@@ -43,7 +43,7 @@ We also confirmed that most differences in protein outputs are accounted for by 
 Terminators also affect protein output with 5-fold changes in fluorescence seen within the same promoter-CDS sets, relative to the tPGK1 terminator of each group (Figure \@ref(fig:pro-ter-platereader-mCherry-mTurq-norm)A).
 We focus on constructs with high-expression promoters due to the poor signal to noise ratio at low expression levels.
 The interaction of coding sequence and terminator is seen most clearly for tPAB1.
-tPAB1 is consistently the most highly expressed terminator in mTurq constructs, but is more variable in mCherry constructs.
+tPAB1 is consistently the most highly expressed terminator in mTurquoise2 constructs, but is more variable in mCherry constructs.
 Meanwhile, tPGK1 highlights the interactions of promoter and terminator.
 tPGK1 is one of the most highly expressing terminators when paired with pPGK1 and pHSP26, but is up to 40% lower in expression when paired with pRPS3 or pRPS13.
 Overall, our results show that the contributions of terminators (including 3'UTRs) to gene expression depend on other parts within the gene.
@@ -128,7 +128,7 @@ Decay motifs generally lead to decay, although ATATTC (mod_NAA) has a weaker eff
 The putative stability motif GTATACCTA (mod_NGG) again has little effect.
 
 We next quantified the effects of removing decay motifs from a native yeast terminator. 
-We selected the cell wall protein PIR1 as our host terminator as it is only 258 bp (@Pelechano2013) and a de-novo-synthesizable terminator that contains the ATATTC, TGTAHMNTA, and HWNCATTWY motifs.
+We selected the cell wall protein PIR1 as our host terminator as it is only 258 bp (@Pelechano2013) and a _de-novo_-synthesizable terminator that contains the ATATTC, TGTAHMNTA, and HWNCATTWY motifs.
 We designed 8 terminators in which the motif occurrences in tPIR1 were replaced by scrambled sequences (Figure \@ref(fig:tPIR1-design-and-qpcr)A).
 We found that the removal of almost any decay motif from tPIR1 results in an increase in mRNA levels (Figure \@ref(fig:tPIR1-design-and-qpcr)B).
 
@@ -139,12 +139,12 @@ Comparison of mRNA abundance across all constructs (Figure \@ref(fig:tRPS3-tTSA1
 The insertion of almost any decay motif into tTSA1 or tRPS3 results in a decrease in mRNA abundance, and removal of these from from tPIR1 results in an increase in mRNA abundance.
 However, the quantitative effects vary depending both on the immediate motif context in the host terminator and on the more distant context given by the promoter.
 
-```{r tRPS3-tTSA1-design-and-qpcr, fig.cap="\\textbf{Motifs inserted into RPS3 and TSA1 host terminators change transcript abundance in RT-qPCR measurements.} (\\textbf{A}) Design of motif insertion sites in native RPS3 and TSA1 terminators, highlighting random insertion used as a negative control. (\\textbf{B}) Fold changes in transcript abundance for tRPS3 constructs paired with 3 promoters; pRPS3, pPGK1 and pSRO9. (\\textbf{C}) Fold changes in transcript abundance for tTSA1 constructs paired with three promoters; pTSA1, pPGK1 and pSRO9. Each diamond represents a biological replicate, averaged over 3 technical replicates. The vertical line represents the mean of all 6 biological replicates. Fold changes are relative to the abundance of the mod\\_NNN construct, i.e. $2^{\\Delta\\Delta Cq}$ (see methods).", fig.align='center'}
+```{r tRPS3-tTSA1-design-and-qpcr, fig.cap="\\textbf{Motifs inserted into RPS3 and TSA1 host terminators change transcript abundance in RT-qPCR measurements.} (\\textbf{A}) Design of motif insertion sites in native RPS3 and TSA1 terminators, highlighting random insertion used as a negative control. (\\textbf{B}) Fold changes in transcript abundance for tRPS3 constructs paired with 3 promoters: pRPS3, pPGK1 and pSRO9. (\\textbf{C}) Fold changes in transcript abundance for tTSA1 constructs paired with three promoters: pTSA1, pPGK1 and pSRO9. Each diamond represents a biological replicate, averaged over 3 technical replicates. The vertical line represents the mean of all 6 biological replicates. Fold changes are relative to the abundance of the mod\\_NNN construct, i.e. $2^{\\Delta\\Delta Cq}$ (see methods).", fig.align='center'}
 knitr::include_graphics(here("results_chapter/figures/insertion_constructs_design_and_qpcr.png"))
 ```
 
 
-```{r tPIR1-design-and-qpcr, fig.cap="\\textbf{Motifs removed from PIR1 host terminators change transcript abundance in RT-qPCR measurements.} (\\textbf{A}) Design of PIR1 constructs with combinations of motifs replaced by random nucleotide sequences. (\\textbf{B}) Fold changes in transcript abundance for tPIR1 constructs paired with 3 promoters; pPIR1, pPGK1 and pSRO9. Each diamond represents a biological replicate, averaged over 3 technical replicates. The vertical line represents the mean of all 6 biological replicates. Fold changes are relative to the abundance of the WT construct, i.e. $2^{\\Delta\\Delta Cq}$ (see methods).", fig.align='center'}
+```{r tPIR1-design-and-qpcr, fig.cap="\\textbf{Motifs removed from PIR1 host terminators change transcript abundance in RT-qPCR measurements.} (\\textbf{A}) Design of PIR1 constructs with combinations of motifs replaced by random nucleotide sequences. (\\textbf{B}) Fold changes in transcript abundance for tPIR1 constructs paired with 3 promoters: pPIR1, pPGK1 and pSRO9. Each diamond represents a biological replicate, averaged over 3 technical replicates. The vertical line represents the mean of all 6 biological replicates. Fold changes are relative to the abundance of the WT construct, i.e. $2^{\\Delta\\Delta Cq}$ (see methods).", fig.align='center'}
 knitr::include_graphics(here("results_chapter/figures/tPIR1_design_and_qpcr.png"))
 ```
 
@@ -184,28 +184,29 @@ knitr::include_graphics(here("results_chapter/figures/qPCR_model_coef_and_pred_v
 
 We next mapped poly(A) site usage in a subset of reporter constructs, for 2 reasons.
 First, changes in poly(A) site usage might mean that motifs placed in our reporters were unintentionally absent from the mature mRNA.
-Second, we wanted to know if motif effects on mRNA abundance might be due to changes in the poly(A) site.
+Second, we wanted to know if motif effects on mRNA abundance might be due to changes in the poly(A) site usage.
 We chose three constructs with large effect sizes in the qPCR results: mod_NAA, mod_HTH and mod_NTN, together with WT and mod_NNN controls, within three promoter-terminator contexts: pRPS3-tRPS3, pPGK1-tRPS3 and pTSA1-tTSA1.
-For these constructs we performed poly(A)-proximal RNA-seq using the QuantSeq Rev protocol with paired-end reads ([@Moll2014] and see methods).
-Read 1 allows precise inference of poly(A) site position while read 2 generally overlaps the CDS, so distinguishing terminators in native loci from reporter constructs.
+For these constructs we performed paired-ends sequencing of 3' mRNA-Seq libraries following QuantSeq protocol ([@Moll2014] and see methods).
+Read 1 allows precise inference of poly(A) site position while read 2 generally overlaps the CDS and allows distinguishing terminators in native loci from reporter constructs.
 We mapped the reads to genome sequences extended by the relevant reporter plasmid sequence.
 
 We detected 1000s of reads on each reporter construct, which is enough to quantify expression confidently as well as to assign poly(A) sites.
 We checked that counts of all other RNAs are highly correlated between samples, giving us confidence that changes in construct detection are meaningful (Figure \@ref(fig:rnaseq-QC-correlation)).
-Transcript abundance, relative to mod_NNN, for most constructs correlate strongly with qPCR results (Figure \@ref(fig:quantseq-polyA-site-usage)A).
+Transcript abundance, relative to mod_NNN, for most constructs correlates strongly with qPCR results (Figure \@ref(fig:quantseq-polyA-site-usage)A).
 However, some constructs were detected as more abundant by RNA-seq for reasons that are unclear.
 
 We display the poly(A) sites as the cumulative fraction of poly(A)-site reads mapped at each location downstream of construct stop codons, out of all reads mapped to the terminator (Figure \@ref(fig:quantseq-polyA-site-usage)B).
-We checked that in other genes the poly(A) site locations were highly reproducible across samples, giving us confidence that changes in construct poly(A) sites are meaningful (Figure \@ref(fig:rnaseq-QC-QuantSeq-and-5PSeq-genomic-polyA)).
-Poly(A) sites are in the same relative positions in native loci and the construct with wild-type terminator (Figure \@ref(fig:rnaseq-QC-genomic-vs-plasmid-polyA)).
+We confirmed that in other genes the poly(A) site locations were highly reproducible across samples, giving us confidence that changes in reporter poly(A) sites are meaningful (Figure \@ref(fig:rnaseq-QC-QuantSeq-and-5PSeq-genomic-polyA)).
+Poly(A) sites are in the same relative positions in native loci and the constructs with wild-type terminator (Figure \@ref(fig:rnaseq-QC-genomic-vs-plasmid-polyA)).
 Then, we compared 3'end positions of reads between modified and wild-type reporter constructs to determine the poly(A) site usage.
 In both wild-type and mod-NNN tTSA1 constructs, the same poly(A) sites are used.
 Surprisingly, tRPS3 mod_NNN constructs appear to be using a novel upstream poly(A) site, that appears in about $50%$ percent of reads and is located upstream of the 3rd motif insertion site.
 For tTSA1 constructs the same poly(A) sites are being used in mod_NNN constructs as wildtype (Figure \@ref(fig:quantseq-polyA-site-usage)B).
 
-Next, we compare changes in poly(A) site usage between constructs with different inserted motifs.
+Next, we compared changes in poly(A) site usage between constructs with different inserted motifs.
 We highlight the 2 major poly(A) sites for the tRPS3 constructs and 2 for the tTSA1 constructs (black vertical lines on the mod_NNN constructs in Figure \@ref(fig:quantseq-polyA-site-usage)B) and track the cumulative fraction of reads upstream of each major site.
 However, for tRPS3 constructs there is a distinct shift to downstream poly(A) sites in constructs with verified, rather than random, motifs inserted. 
+There are also smaller differences in poly(A) site usage between constructs with different motifs.
 For tTSA1 constructs there is little change in poly(A) site usage across all constructs.
 
 
@@ -213,7 +214,7 @@ For tTSA1 constructs there is little change in poly(A) site usage across all con
 knitr::include_graphics(here("results_chapter/figures/polya_usage_plot_QuantSeq.png"))
 ```
 
-We then asked whether modifications in the 3'-UTR region can impact translation through changing ribosome dynamics and 5'-3' co-translational degradation pathway.
+We then asked whether modifications in the 3'-UTR region can impact translation through changing ribosome dynamics and 5'-3' co-translational degradation pathway using the 5PSeq method targeting the 3'-end regions of mRNA.
 Our 5PSeq data shows that there are no significant changes in ribosome stalling between wild-type and modified reporter constructs (Figure \@ref(fig:rnaseq-QC-genomic-vs-plasmid-polyA)), suggesting that mechanisms by which inserted motifs regulate the expression of reporter protein do not impact ribosome dynamics.
 Moreover, the poly(A) site distribution for each construct matches that obtained from QuantSeq data, suggesting that 3'-UTR isoforms are not differentially degraded using this pathway regardless of the motifs inserted.
-Finally, the abundances of different reporter mRNAs from different constructs correlate well between 5PSeq and QuantSeq data **correlation plot needed**, but are not correlated genome wide (Figure \@ref(fig:rnaseq-QC-QuantSeq-vs-5PSeq)).
+Finally, the abundances of different reporter mRNAs from different constructs correlate well between 5PSeq and QuantSeq data **refer to sup figure 11c**.

--- a/results_chapter/results.Rmd
+++ b/results_chapter/results.Rmd
@@ -199,7 +199,7 @@ We display the poly(A) sites as the cumulative fraction of poly(A)-site reads ma
 We confirmed that in other genes the poly(A) site locations were highly reproducible across samples, giving us confidence that changes in reporter poly(A) sites are meaningful (Figure \@ref(fig:rnaseq-QC-QuantSeq-and-5PSeq-genomic-polyA)).
 Poly(A) sites are in the same relative positions in native loci and the constructs with wild-type terminator (Figure \@ref(fig:rnaseq-QC-genomic-vs-plasmid-polyA)).
 Then, we compared 3'end positions of reads between modified and wild-type reporter constructs to determine the poly(A) site usage.
-In both wild-type and mod-NNN tTSA1 constructs, the same poly(A) sites are used.
+In both wild-type and mod_NNN tTSA1 constructs, the same poly(A) sites are used.
 Surprisingly, tRPS3 mod_NNN constructs appear to be using a novel upstream poly(A) site, that appears in about $50%$ percent of reads and is located upstream of the 3rd motif insertion site.
 For tTSA1 constructs the same poly(A) sites are being used in mod_NNN constructs as wildtype (Figure \@ref(fig:quantseq-polyA-site-usage)B).
 
@@ -214,7 +214,8 @@ For tTSA1 constructs there is little change in poly(A) site usage across all con
 knitr::include_graphics(here("results_chapter/figures/polya_usage_plot_QuantSeq.png"))
 ```
 
-We then asked whether modifications in the 3'-UTR region can impact translation through changing ribosome dynamics and 5'-3' co-translational degradation pathway using the 5PSeq method targeting the 3'-end regions of mRNA.
-Our 5PSeq data shows that there are no significant changes in ribosome stalling between wild-type and modified reporter constructs (Figure \@ref(fig:rnaseq-QC-genomic-vs-plasmid-polyA)), suggesting that mechanisms by which inserted motifs regulate the expression of reporter protein do not impact ribosome dynamics.
+We then asked whether modifications in the 3'-UTR region impact 5'-3' degradation following mRNA decapping, using the 5PSeq method targeted to the 3'-end regions of mRNA [@Pelechano2016].
+5PSeq can detect changing ribosome dynamics through 5'-3' co-translational degradation, however, the novel modification to 5Pseq here uses an anchored oligo(dT) reverse primer so detects only the poly(A)-site proximal region of the mRNA instead of the entire coding sequence.
+Our 5PSeq data finds no detectable changes in 5'-phosphorylated intermediates between wild-type and modified reporter constructs, and thus does not indicate detectable changes in ribosome dynamics near the 3' end of transcripts (Figure \@ref(fig:rnaseq-QC-genomic-vs-plasmid-polyA)).
 Moreover, the poly(A) site distribution for each construct matches that obtained from QuantSeq data, suggesting that 3'-UTR isoforms are not differentially degraded using this pathway regardless of the motifs inserted.
-Finally, the abundances of different reporter mRNAs from different constructs correlate well between 5PSeq and QuantSeq data **refer to sup figure 11c**.
+Finally, the abundances of different reporter mRNAs from different constructs correlate well between 5PSeq and QuantSeq data (Figure \@ref(fig:rnaseq-QC-QuantSeq-vs-5PSeq}C).

--- a/results_chapter/results.Rmd
+++ b/results_chapter/results.Rmd
@@ -219,3 +219,6 @@ We then asked whether modifications in the 3'-UTR region impact 5'-3' degradatio
 Our 5PSeq data finds no detectable changes in 5'-phosphorylated intermediates between wild-type and modified reporter constructs, and thus does not indicate detectable changes in ribosome dynamics near the 3' end of transcripts (Figure \@ref(fig:rnaseq-QC-genomic-vs-plasmid-polyA)).
 Moreover, the poly(A) site distribution for each construct matches that obtained from QuantSeq data, suggesting that 3'-UTR isoforms are not differentially degraded using this pathway regardless of the motifs inserted.
 Finally, the abundances of different reporter mRNAs from different constructs correlate well between 5PSeq and QuantSeq data (Figure \@ref(fig:rnaseq-QC-QuantSeq-vs-5PSeq}C).
+
+Overall, poly(A) site mapping showed that most reporter mRNAs retained the expected poly(A) site and motifs, except for a new alternative poly(A) site in tRPS3 mod_NNN constructs.
+This highlights the potential for unexpected consequences from composing cis-regulatory elements, even when introducint "random" insertions of no known function.


### PR DESCRIPTION
I added small edits to results and discussion sections.

I think that supplementary figure 14 is unnecessary and doesn't bring any new information. If it has to be included in the supplement, I don't think it needs to be refered to in detail in results section - maybe in general as "QC figures". In the current form it can only confuse the reader, because it suggests that we should have some expectations of genome-wide correlation between 5PS and QS (did we expect it to be well correlated or not?). Plus, we're not comparing genome-wide quantification between two methods, but relative differences between reporter constructs.